### PR TITLE
Correct reticulate path to provide direct path to python3 binary

### DIFF
--- a/installpkgs.R
+++ b/installpkgs.R
@@ -39,4 +39,4 @@ system('bash ./setup.sh')
 # Set up Python for reticulate
 # This path is using the miniconda installation, which is located
 # inside of the home directory based on how the setup script installed it
-reticulate::use_python("~/miniconda/bin", required = TRUE)
+reticulate::use_python("~/miniconda/bin/python3", required = TRUE)


### PR DESCRIPTION
The latest version of {reticulate} seems to require that instead of providing the /bin directory of the python executable, that the actual binary executable is provided instead. This simply adds that path to the `reticulate::use_python()` call. 